### PR TITLE
linux-networking: disable cloud mgmt for hosts, update hosts 

### DIFF
--- a/linux-networking/99_disable_hosts.cfg
+++ b/linux-networking/99_disable_hosts.cfg
@@ -1,0 +1,1 @@
+manage_etc_hosts: False

--- a/linux-networking/tasks/main.yml
+++ b/linux-networking/tasks/main.yml
@@ -1,3 +1,10 @@
+- name: disable cloud for /etc/hosts
+  copy:
+    src: 99_disable_hosts.cfg
+    dest: /etc/cloud/cloud.cfg.d/
+    owner: root
+  tags: configure
+
 - name: generate /etc/hosts
   template:
     src: hosts

--- a/linux-networking/templates/hosts
+++ b/linux-networking/templates/hosts
@@ -24,7 +24,9 @@
 {% endif %}
 
 # The following lines are desirable for IPv6 capable hosts
-::1     localhost ip6-localhost ip6-loopback
+::1 ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 ff02::3 ip6-allhosts


### PR DESCRIPTION
new versions of ubuntu use cloud config with /etc/hosts management turned on by default. Since our roles provision /etc/hosts from the ansible template, this change switches off the management by cloud config. It also updates the /etc/hosts template to match the default one from the ubuntu distribution packages.