### PR TITLE
linux-networking: Sorted interfaces

### DIFF
--- a/linux-networking/templates/interfaces
+++ b/linux-networking/templates/interfaces
@@ -64,15 +64,15 @@ iface lo inet loopback
 
 
 {% set ordered_networking = networking.copy() %}
-{% for iface in networking %}
-{% if iface.startswith('bond') %}
-{% set x=ordered_networking[iface].update({'order': 10})  %}
-{% elif iface.startswith('vlan') %}
-{% set x=ordered_networking[iface].update({'order': 20})  %}
-{% elif iface.startswith('brVlan') %}
-{% set x=ordered_networking[iface].update({'order': 30})  %}
-{% else %}
-{% set x=ordered_networking[iface].update({'order': 100})  %}
+{% for iface_name,item in networking.items() %}
+{% if iface_name.startswith('bond') and 'order' not in item %}
+{% set x=ordered_networking[iface_name].update({'order': 10})  %}
+{% elif iface_name.startswith('vlan') and 'order' not in item %}
+{% set x=ordered_networking[iface_name].update({'order': 20})  %}
+{% elif iface_name.startswith('brVlan') and 'order' not in item %}
+{% set x=ordered_networking[iface_name].update({'order': 30})  %}
+{% elif 'order' not in item %}
+{% set x=ordered_networking[iface_name].update({'order': 100})  %}
 {% endif %}
 {% endfor %}
 

--- a/linux-networking/templates/interfaces
+++ b/linux-networking/templates/interfaces
@@ -62,7 +62,24 @@ iface lo inet loopback
 {% endif %}
 {%- endmacro -%}
 
-{% for iface_name,item in networking.items() %}
+
+{% set ordered_networking = networking.copy() %}
+{% for iface in networking %}
+{% if iface.startswith('bond') %}
+{% set x=ordered_networking[iface].update({'order': 10})  %}
+{% elif iface.startswith('vlan') %}
+{% set x=ordered_networking[iface].update({'order': 20})  %}
+{% elif iface.startswith('brVlan') %}
+{% set x=ordered_networking[iface].update({'order': 30})  %}
+{% else %}
+{% set x=ordered_networking[iface].update({'order': 100})  %}
+{% endif %}
+{% endfor %}
+
+
+{% for iterator in ordered_networking.items() | sort(attribute='1.order') %}
+{% set iface_name = iterator[0] %}
+{% set item = iterator[1] %}
 
 # {{ item }}
 {% if iface_name is not match(":") %}
@@ -96,4 +113,4 @@ iface {{ iface_name }} inet dhcp
 iface {{ iface_name }} inet manual
 {{ configure_interface(item, iface_name) }}
 {% endif %}
-{%endfor %}
+{% endfor %}


### PR DESCRIPTION
sort the interfaces to satisfy the desired orderering while respecting the given order beforehand